### PR TITLE
version 1.1.0: nodejs child_process exec used

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ var Cordova = require('node-cordova');
 var app = new Cordova('/path/to/my/app');
 
 app.create('com.fancy.apps', 'App Name');
+
+app.addPlatform('android', function(err, stdout, stderr){
+    // ...
+});
 ```
 
-## Methods of Cordova class
+## Methods of Cordova class
 
 *Note:* all methods can take a callback parameter. It that parameter is provided the method will run asynchronously, otherwise it will run synchronously. Callback must be a function which accepts a single parameter that will be either an error string (the output of the cordova command) or undefined if everything went ok.
 
@@ -58,7 +62,7 @@ app.create('com.fancy.apps', 'App Name');
  * @return {String|undefined}
  ```
 
-### removePlugin
+### removePlugin
 ```
  * Removes a plugin from the app
  * @method removePlugin

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var shell = require('shelljs'),
+var exec = require('child_process').exec,
     fs = require('fs'),
     path = require('path');
 
@@ -15,22 +15,20 @@ var CORDOVA_PATH = path.join(
 /**
  * Executes a terminal command
  * @param  {String}   cmd      Command to execute
+ * @param  {String}   cwd      Current working directory
  * @param  {Function} callback Callback only if the command is async
  * @return {String|undefined}
  */
-var cmd = function (cmd, callback) {
+var cmd = function (cmd, cwd, callback) {
     var async = typeof callback === 'function';
-    var _callback = function (code, output) {
-        callback(code !== 0 ? output : undefined)
-    };
 
-    var result = shell.exec(
+    var result = exec(
         cmd,
-        {silent: true},
-        async ? _callback : undefined
+        {cwd: cwd},
+        async ? callback : undefined
     );
 
-    return result.code !== 0 && !async ? result.output : undefined;
+    return result.code !== 0 && !async ? result.stdout : undefined;
 };
 
 /**
@@ -55,14 +53,6 @@ var Cordova = function (path) {
 };
 
 /**
- * Changes the current directory to the app directory
- * @method go
- */
-Cordova.prototype.go = function () {
-    shell.cd(this.path);
-};
-
-/**
  * Creates a new cordova project at the path given when the Cordova instance
  * was created. If callback param is provided the result will be async.
  * @method create
@@ -72,7 +62,7 @@ Cordova.prototype.go = function () {
  * @return {String|undefined}
  */
 Cordova.prototype.create = function (packageName, name, callback) {
-    return cmd(buildCommand('create', this.path, packageName, name), callback);
+    return cmd(buildCommand('create', this.path, packageName, name), this.path, callback);
 };
 
 /**
@@ -83,8 +73,7 @@ Cordova.prototype.create = function (packageName, name, callback) {
  * @return {String|undefined}
  */
 Cordova.prototype.addPlatform = function (platform, callback) {
-    this.go();
-    return cmd(buildCommand('platform', 'add', platform), callback);
+    return cmd(buildCommand('platform', 'add', platform), this.path, callback);
 };
 
 /**
@@ -95,8 +84,7 @@ Cordova.prototype.addPlatform = function (platform, callback) {
  * @return {String|undefined}
  */
 Cordova.prototype.removePlatform = function (platform, callback) {
-    this.go();
-    return cmd(buildCommand('platform', 'rm', platform), callback);
+    return cmd(buildCommand('platform', 'rm', platform), this.path, callback);
 };
 
 /**
@@ -107,8 +95,7 @@ Cordova.prototype.removePlatform = function (platform, callback) {
  * @return {String|undefined}
  */
 Cordova.prototype.addPlugin = function (plugin, callback) {
-    this.go();
-    return cmd(buildCommand('plugin', 'add', plugin), callback);
+    return cmd(buildCommand('plugin', 'add', plugin), this.path, callback);
 };
 
 /**
@@ -119,8 +106,7 @@ Cordova.prototype.addPlugin = function (plugin, callback) {
  * @return {String|undefined}
  */
 Cordova.prototype.removePlugin = function (plugin, callback) {
-    this.go();
-    return cmd(buildCommand('plugin', 'rm', plugin), callback);
+    return cmd(buildCommand('plugin', 'rm', plugin), this.path, callback);
 };
 
 /**
@@ -131,8 +117,7 @@ Cordova.prototype.removePlugin = function (plugin, callback) {
  * @return {String|undefined}
  */
 Cordova.prototype.prepare = function (platform, callback) {
-    this.go();
-    return cmd(buildCommand('prepare', platform), callback);
+    return cmd(buildCommand('prepare', platform), this.path, callback);
 };
 
 /**
@@ -143,8 +128,7 @@ Cordova.prototype.prepare = function (platform, callback) {
  * @return {String|undefined}
  */
 Cordova.prototype.compile = function (platform, callback) {
-    this.go();
-    return cmd(buildCommand('compile', platform), callback);
+    return cmd(buildCommand('compile', platform), this.path, callback);
 };
 
 /**
@@ -155,8 +139,7 @@ Cordova.prototype.compile = function (platform, callback) {
  * @return {String|undefined}
  */
 Cordova.prototype.build = function (platform, callback) {
-    this.go();
-    return cmd(buildCommand('build', platform), callback);
+    return cmd(buildCommand('build', platform), this.path, callback);
 };
 
 module.exports = Cordova;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cordova",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Wrapper for the Cordova CLI that you can use programmatically directly from Node.js.",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/mvader/node-cordova",
   "dependencies": {
-    "shelljs": "0.3.*",
-    "cordova": "4.2.*"
+    "cordova": "4.3.*"
   }
 }


### PR DESCRIPTION
shelljs replaced by node child_process exec.
Added upgrade the version 4.3.\* of cordova to the dependencies.
Example added to README.md
